### PR TITLE
explicit evm version to homestead

### DIFF
--- a/src/client/app/shared/constants/version.ts
+++ b/src/client/app/shared/constants/version.ts
@@ -1,2 +1,2 @@
 // update version here
-export const VERSION = '0.0.5';
+export const VERSION = '0.0.7';

--- a/src/client/app/shared/services/compiler/compiler-input.ts
+++ b/src/client/app/shared/services/compiler/compiler-input.ts
@@ -8,6 +8,7 @@ export const compilerInput = (sources: any, optimize: boolean = false, libraries
         enabled: optimize,
         runs: 200
       },
+      evmVersion: "homestead",
       libraries: libraries,
       outputSelection: {
         '*': {


### PR DESCRIPTION
added explicit evm version set to homestead, was causing issues with certain builtin functions (like sha256) otherwise.